### PR TITLE
Fix overlapping exported config

### DIFF
--- a/config
+++ b/config
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 export MARIADB_IMAGE=${MARIADB_IMAGE:="mariadb"}
 export MARIADB_IMAGE_VERSION=${MARIADB_IMAGE_VERSION:="10.0.21"}
-export MARIADB_ROOT=/var/lib/dokku/services/mariadb
+export MARIADB_ROOT=${MARIADB_ROOT:="/var/lib/dokku/services/mariadb"}
 
 export PLUGIN_COMMAND_PREFIX="mariadb"
-export PLUGIN_DATA_ROOT=${PLUGIN_DATA_ROOT:="$MARIADB_ROOT"}
+export PLUGIN_DATA_ROOT=$MARIADB_ROOT
 export PLUGIN_DATASTORE_PORTS=(3306)
 export PLUGIN_DEFAULT_ALIAS="DATABASE"
 export PLUGIN_IMAGE=$MARIADB_IMAGE

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -8,9 +8,10 @@ export PLUGIN_PATH="$DOKKU_ROOT/plugins"
 export PLUGIN_ENABLED_PATH="$PLUGIN_PATH"
 export PLUGIN_AVAILABLE_PATH="$PLUGIN_PATH"
 export PLUGIN_CORE_AVAILABLE_PATH="$PLUGIN_PATH"
-export PLUGIN_DATA_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fixtures"
+export MARIADB_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fixtures"
+export PLUGIN_DATA_ROOT="$MARIADB_ROOT"
 
-mkdir -p $PLUGIN_DATA_ROOT
+mkdir -p "$PLUGIN_DATA_ROOT"
 rm -rf "${PLUGIN_DATA_ROOT:?}"/*
 
 flunk() {


### PR DESCRIPTION
If using multiple official dokku datastorage plugins, it is possible to get into a case where the `PLUGIN_DATA_ROOT` would be set incorrectly for other plugins.

Refs dokku/dokku-redis#20