### PR TITLE
Fix /var/lib/mysql volume mount point

### DIFF
--- a/commands
+++ b/commands
@@ -34,7 +34,7 @@ case "$1" in
 
     dokku_log_info1 "Starting container"
     SERVICE_NAME=$(get_service_name "$SERVICE")
-    ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT:/var/lib/mariadb" -e "MYSQL_ROOT_PASSWORD=$rootpassword" -e MYSQL_USER=mariadb -e "MYSQL_PASSWORD=$password" -e "MYSQL_DATABASE=$SERVICE" -d --restart always --label dokku=service --label dokku.service=mariadb "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
+    ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT/data:/var/lib/mysql" -e "MYSQL_ROOT_PASSWORD=$rootpassword" -e MYSQL_USER=mariadb -e "MYSQL_PASSWORD=$password" -e "MYSQL_DATABASE=$SERVICE" -d --restart always --label dokku=service --label dokku.service=mariadb "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
     echo "$ID" > "$SERVICE_ROOT/ID"
 
     dokku_log_verbose_quiet "Waiting for container to be ready"


### PR DESCRIPTION
Mariadb uses` /var/lib/mysql` and not `/var/lib/mariadb`

After upgrading, users will need to manually copy `/var/lib/docker/volumes/../_data` to `/var/lib/dokku/services/mariadb/<app>/data`.

You can get the current mount points using docker inspect <container-id>.

```
"Mounts": [
    {
        "Source": "/var/lib/dokku/services/mariadb/<app>",
        "Destination": "/var/lib/mariadb",
        "Mode": "",
        "RW": true
    },
    {
        "Name": "51fe99a1645ad115a5dcf99e9e4805bbea8d9c07147f3144a0677275fca412b5",
        "Source": "/var/lib/docker/volumes/51fe99a1645ad115a5dcf99e9e4805bbea8d9c07147f3144a0677275fca412b5/_data",
        "Destination": "/var/lib/mysql",
        "Driver": "local",
        "Mode": "",
        "RW": true
    }
]
```