### PR TITLE
Remove quotes from database name

### DIFF
--- a/functions
+++ b/functions
@@ -252,7 +252,7 @@ service_create_container() {
   local ROOTPASSWORD=$(cat "$SERVICE_ROOT/ROOTPASSWORD")
   local PASSWORD=$(cat "$SERVICE_ROOT/PASSWORD")
 
-  ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT/data:/var/lib/mysql" -e "MYSQL_ROOT_PASSWORD=$ROOTPASSWORD" -e MYSQL_USER=mariadb -e "MYSQL_PASSWORD=$PASSWORD" -e "MYSQL_DATABASE=\`$SERVICE\`" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=mariadb "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
+  ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT/data:/var/lib/mysql" -e "MYSQL_ROOT_PASSWORD=$ROOTPASSWORD" -e MYSQL_USER=mariadb -e "MYSQL_PASSWORD=$PASSWORD" -e "MYSQL_DATABASE=$SERVICE" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=mariadb "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
   echo "$ID" > "$SERVICE_ROOT/ID"
 
   dokku_log_verbose_quiet "Waiting for container to be ready"


### PR DESCRIPTION
Removed the quotes here, because the init scripts of the container will add the quotes to the name of the database.

This line in the docker library also adds the quotes.
https://github.com/docker-library/mariadb/blob/489a5bb656d2dbc583e0b0e4094fae6c32bec1a4/10.1/docker-entrypoint.sh#L81