### PR TITLE
Adds possibility to set encryption for s3 backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ sudo dokku plugin:install https://github.com/dokku/dokku-mariadb.git mariadb
 mariadb:backup <name> <bucket> (--use-iam) Create a backup of the mariadb service to an existing s3 bucket
 mariadb:backup-auth <name> <aws_access_key_id> <aws_secret_access_key> (<aws_default_region>) (<aws_signature_version>) (<endpoint_url>) Sets up authentication for backups on the mariadb service
 mariadb:backup-deauth <name>     Removes backup authentication for the mariadb service
+mariadb:backup-set-encryption <name> <encryption_key>, Sets up GPG encryption for future backups of the mariadb service
+mariadb:backup-unset-encryption <name>, Removes backup encryption for future backups of the mariadb service
 mariadb:backup-schedule <name> <schedule> <bucket> Schedules a backup of the mariadb service
 mariadb:backup-unschedule <name> Unschedules the backup of the mariadb service
 mariadb:clone <name> <new-name>  Create container <new-name> then copy data from <name> into <new-name>

--- a/commands
+++ b/commands
@@ -23,6 +23,14 @@ case "$1" in
     "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/subcommands/backup-deauth" "$@"
     ;;
 
+  $PLUGIN_COMMAND_PREFIX:backup-set-encryption)
+    "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/subcommands/backup-set-encryption" "$@"
+    ;;
+
+  $PLUGIN_COMMAND_PREFIX:backup-unset-encryption)
+    "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/subcommands/backup-unset-encryption" "$@"
+    ;;
+
   $PLUGIN_COMMAND_PREFIX:backup-schedule)
     "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/subcommands/backup-schedule" "$@"
     ;;
@@ -107,6 +115,8 @@ case "$1" in
     $PLUGIN_COMMAND_PREFIX:backup <name> <bucket> (--use-iam), Create a backup of the $PLUGIN_COMMAND_PREFIX service to an existing s3 bucket
     $PLUGIN_COMMAND_PREFIX:backup-auth <name> <aws_access_key_id> <aws_secret_access_key> (<aws_default_region>) (<aws_signature_version>) (<endpoint_url>), Sets up authentication for backups on the $PLUGIN_COMMAND_PREFIX service
     $PLUGIN_COMMAND_PREFIX:backup-deauth <name>, Removes backup authentication for the $PLUGIN_COMMAND_PREFIX service
+    $PLUGIN_COMMAND_PREFIX:backup-set-encryption <name> <encryption_key>, Sets up GPG encryption for future backups of the $PLUGIN_COMMAND_PREFIX service
+    $PLUGIN_COMMAND_PREFIX:backup-unset-encryption <name>, Removes backup encryption for future backups of the $PLUGIN_COMMAND_PREFIX service
     $PLUGIN_COMMAND_PREFIX:backup-schedule <name> <schedule> <bucket>, Schedules a backup of the $PLUGIN_COMMAND_PREFIX service
     $PLUGIN_COMMAND_PREFIX:backup-unschedule <name>, Unschedules the backup of the $PLUGIN_COMMAND_PREFIX service
     $PLUGIN_COMMAND_PREFIX:clone <name> <new-name>, Create container <new-name> then copy data from <name> into <new-name>

--- a/common-functions
+++ b/common-functions
@@ -107,6 +107,7 @@ service_backup() {
   declare desc="Creates a backup of a service to an existing s3 bucket"
   declare SERVICE="$1" BUCKET_NAME="$2" S3_FLAG="$3"
   local BACKUP_CONFIG_ROOT="$PLUGIN_DATA_ROOT/$SERVICE/backup"
+  local BACKUP_ENCRYPTION_CONFIG_ROOT="$PLUGIN_DATA_ROOT/$SERVICE/backup-encryption"
   local AWS_ACCESS_KEY_ID_FILE="$BACKUP_CONFIG_ROOT/AWS_ACCESS_KEY_ID"
   local AWS_SECRET_ACCESS_KEY_FILE="$BACKUP_CONFIG_ROOT/AWS_SECRET_ACCESS_KEY"
   local BACKUP_PARAMETERS=""
@@ -141,8 +142,12 @@ service_backup() {
     BACKUP_PARAMETERS="$BACKUP_PARAMETERS -e ENDPOINT_URL=$(cat "$BACKUP_CONFIG_ROOT/ENDPOINT_URL")"
   fi
 
+  if [[ -f "$BACKUP_ENCRYPTION_CONFIG_ROOT/ENCRYPTION_KEY" ]]; then
+    BACKUP_PARAMETERS="$BACKUP_PARAMETERS -e ENCRYPTION_KEY=$(cat "$BACKUP_ENCRYPTION_CONFIG_ROOT/ENCRYPTION_KEY")"
+  fi
+
   # shellcheck disable=SC2086
-  docker run $BACKUP_PARAMETERS dokkupaas/s3backup:0.7.0
+  docker run $BACKUP_PARAMETERS dokkupaas/s3backup:0.8.0
 }
 
 service_backup_auth() {
@@ -196,6 +201,25 @@ service_backup_unschedule() {
   local CRON_FILE="/etc/cron.d/dokku-${PLUGIN_COMMAND_PREFIX}-${SERVICE}"
 
   sudo /bin/rm -f "$CRON_FILE"
+}
+
+service_backup_set_encryption() {
+  declare desc="Sets up backup encryption"
+  declare SERVICE="$1" ENCRYPTION_KEY="$2"
+  local SERVICE_ROOT="${PLUGIN_DATA_ROOT}/${SERVICE}"
+  local SERVICE_BACKUP_ROOT="${SERVICE_ROOT}/backup-encryption/"
+
+  mkdir -p "$SERVICE_BACKUP_ROOT"
+  echo "$ENCRYPTION_KEY" > "${SERVICE_BACKUP_ROOT}/ENCRYPTION_KEY"
+}
+
+service_backup_unset_encryption() {
+  declare desc="Removes backup encryption"
+  declare SERVICE="$1"
+  local SERVICE_ROOT="${PLUGIN_DATA_ROOT}/${SERVICE}"
+  local SERVICE_BACKUP_ROOT="${SERVICE_ROOT}/backup-encryption/"
+
+  rm -rf "$SERVICE_BACKUP_ROOT"
 }
 
 service_enter() {

--- a/common-functions
+++ b/common-functions
@@ -207,19 +207,19 @@ service_backup_set_encryption() {
   declare desc="Sets up backup encryption"
   declare SERVICE="$1" ENCRYPTION_KEY="$2"
   local SERVICE_ROOT="${PLUGIN_DATA_ROOT}/${SERVICE}"
-  local SERVICE_BACKUP_ROOT="${SERVICE_ROOT}/backup-encryption/"
+  local SERVICE_BACKUP_ENCRYPTION_ROOT="${SERVICE_ROOT}/backup-encryption/"
 
-  mkdir -p "$SERVICE_BACKUP_ROOT"
-  echo "$ENCRYPTION_KEY" > "${SERVICE_BACKUP_ROOT}/ENCRYPTION_KEY"
+  mkdir -p "$SERVICE_BACKUP_ENCRYPTION_ROOT"
+  echo "$ENCRYPTION_KEY" > "${SERVICE_BACKUP_ENCRYPTION_ROOT}/ENCRYPTION_KEY"
 }
 
 service_backup_unset_encryption() {
   declare desc="Removes backup encryption"
   declare SERVICE="$1"
   local SERVICE_ROOT="${PLUGIN_DATA_ROOT}/${SERVICE}"
-  local SERVICE_BACKUP_ROOT="${SERVICE_ROOT}/backup-encryption/"
+  local SERVICE_BACKUP_ENCRYPTION_ROOT="${SERVICE_ROOT}/backup-encryption/"
 
-  rm -rf "$SERVICE_BACKUP_ROOT"
+  rm -rf "$SERVICE_BACKUP_ENCRYPTION_ROOT"
 }
 
 service_enter() {

--- a/install
+++ b/install
@@ -13,7 +13,7 @@ plugin-install() {
   pull-docker-image "${PLUGIN_IMAGE}:${PLUGIN_IMAGE_VERSION}"
   pull-docker-image "svendowideit/ambassador:latest"
   pull-docker-image "dokkupaas/wait:0.2"
-  pull-docker-image "dokkupaas/s3backup:0.7.0"
+  pull-docker-image "dokkupaas/s3backup:0.8.0"
   pull-docker-image "busybox:latest"
 
   mkdir -p "$PLUGIN_DATA_ROOT" || echo "Failed to create $PLUGIN_SERVICE directory"

--- a/subcommands/backup-set-encryption
+++ b/subcommands/backup-set-encryption
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+source "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/config"
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_BASE_PATH/common/functions"
+source "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/functions"
+
+mariadb-backup-set-encryption-cmd() {
+  declare desc="sets encryption for all future backups of $PLUGIN_SERVICE service"
+  local cmd="$PLUGIN_COMMAND_PREFIX:backup-set-encryption" argv=("$@"); [[ ${argv[0]} == "$cmd" ]] && shift 1
+  declare SERVICE="$1" ENCRYPTION_KEY="$2"
+
+  [[ -z "$SERVICE" ]] && dokku_log_fail "Please specify a name for the service"
+  [[ -z "$ENCRYPTION_KEY" ]] && dokku_log_fail "Please specify a GPG encryption key"
+  verify_service_name "$SERVICE"
+  service_backup_set_encryption "$SERVICE" "$ENCRYPTION_KEY"
+}
+
+mariadb-backup-set-encryption-cmd "$@"

--- a/subcommands/backup-unset-encryption
+++ b/subcommands/backup-unset-encryption
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+source "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/config"
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_BASE_PATH/common/functions"
+source "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/functions"
+
+mariadb-backup-unset-encryption-cmd() {
+  declare desc="unsets encryption for future backups of the $PLUGIN_SERVICE service"
+  local cmd="$PLUGIN_COMMAND_PREFIX:backup-unset-encryption" argv=("$@"); [[ ${argv[0]} == "$cmd" ]] && shift 1
+  declare SERVICE="$1"
+
+  [[ -z "$SERVICE" ]] && dokku_log_fail "Please specify a name for the service"
+  verify_service_name "$SERVICE"
+  service_backup_unset_encryption "$SERVICE"
+}
+
+mariadb-backup-unset-encryption-cmd "$@"


### PR DESCRIPTION
New commands added:
mariadb:backup-set-encryption <name> <encryption_key>, Sets up GPG encryption for future backups of the mariadb service
mariadb:backup-unset-encryption <name>, Removes backup encryption for future backups of the mariadb service