### PR TITLE
feat: re-allow dashes in names

### DIFF
--- a/common-functions
+++ b/common-functions
@@ -19,10 +19,14 @@ get_container_ip() {
 
 get_database_name() {
   declare desc="Retrieves a sanitized database name"
-  declare DATABASE="$1"
-  # some datastores do not like special characters in database names
-  # so we need to normalize them out
-  echo "$DATABASE" | tr .- _
+  declare SERVICE="$1"
+  local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
+
+  if [[ ! -f "$SERVICE_ROOT/DATABASE_NAME" ]]; then
+    echo "$SERVICE" > "$SERVICE_ROOT/DATABASE_NAME"
+  fi
+
+  cat "$SERVICE_ROOT/DATABASE_NAME"
 }
 
 get_random_ports() {
@@ -89,7 +93,7 @@ is_valid_service_name() {
   declare SERVICE="$1"
   [[ -z "$SERVICE" ]] && return 1
 
-  if [[ "$SERVICE" =~ ^[A-Za-z0-9_]+$ ]]; then
+  if [[ "$SERVICE" =~ ^[A-Za-z0-9_-]+$ ]]; then
     return 0
   fi
 
@@ -779,4 +783,14 @@ verify_service_name() {
   [[ -z "$SERVICE" ]] && dokku_log_fail "(verify_service_name) SERVICE must not be null"
   [[ ! -d "$PLUGIN_DATA_ROOT/$SERVICE" ]] && dokku_log_fail "$PLUGIN_SERVICE service $SERVICE does not exist"
   return 0
+}
+
+write_database_name() {
+  declare desc="Writes a sanitized database name"
+  declare SERVICE="$1"
+  local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
+
+  # some datastores do not like special characters in database names
+  # so we need to normalize them out
+  echo "$SERVICE" | tr .- _ > "$SERVICE_ROOT/DATABASE_NAME"
 }

--- a/functions
+++ b/functions
@@ -13,11 +13,12 @@ service_connect() {
   local SERVICE="$1"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local SERVICE_NAME="$(get_service_name "$SERVICE")"
+  local DATABASE_NAME="$(get_database_name "$SERVICE")"
   local PASSWORD="$(cat "$SERVICE_ROOT/PASSWORD")"
   local SERVICE_TTY_OPTS
   has_tty && SERVICE_TTY_OPTS="-t"
 
-  docker exec -i $SERVICE_TTY_OPTS "$SERVICE_NAME" env TERM="$TERM" mysql --user=mariadb --password="$PASSWORD" --database="$SERVICE"
+  docker exec -i $SERVICE_TTY_OPTS "$SERVICE_NAME" env TERM="$TERM" mysql --user=mariadb --password="$PASSWORD" --database="$DATABASE_NAME"
 }
 
 service_create() {
@@ -67,6 +68,8 @@ service_create() {
   else
     echo "" >"$SERVICE_ROOT/ENV"
   fi
+
+  write_database_name "$SERVICE"
   service_create_container "$SERVICE"
 }
 
@@ -77,8 +80,9 @@ service_create_container() {
   local SERVICE_NAME="$(get_service_name "$SERVICE")"
   local ROOTPASSWORD="$(cat "$SERVICE_ROOT/ROOTPASSWORD")"
   local PASSWORD="$(cat "$SERVICE_ROOT/PASSWORD")"
+  local DATABASE_NAME="$(get_database_name "$SERVICE")"
 
-  ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_HOST_ROOT/data:/var/lib/mysql" -v "$SERVICE_HOST_ROOT/config:/etc/mysql/conf.d" -e "MYSQL_ROOT_PASSWORD=$ROOTPASSWORD" -e MYSQL_USER=mariadb -e "MYSQL_PASSWORD=$PASSWORD" -e "MYSQL_DATABASE=$SERVICE" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=mariadb "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
+  ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_HOST_ROOT/data:/var/lib/mysql" -v "$SERVICE_HOST_ROOT/config:/etc/mysql/conf.d" -e "MYSQL_ROOT_PASSWORD=$ROOTPASSWORD" -e MYSQL_USER=mariadb -e "MYSQL_PASSWORD=$PASSWORD" -e "MYSQL_DATABASE=$DATABASE_NAME" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=mariadb "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
   echo "$ID" >"$SERVICE_ROOT/ID"
 
   dokku_log_verbose_quiet "Waiting for container to be ready"
@@ -92,10 +96,11 @@ service_export() {
   local SERVICE="$1"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local SERVICE_NAME="$(get_service_name "$SERVICE")"
+  local DATABASE_NAME="$(get_database_name "$SERVICE")"
   local PASSWORD="$(cat "$SERVICE_ROOT/PASSWORD")"
 
   [[ -n $SSH_TTY ]] && stty -opost
-  docker exec "$SERVICE_NAME" mysqldump --user=mariadb --password="$PASSWORD" "$SERVICE"
+  docker exec "$SERVICE_NAME" mysqldump --user=mariadb --password="$PASSWORD" "$DATABASE_NAME"
   status=$?
   [[ -n $SSH_TTY ]] && stty opost
   exit $status
@@ -106,12 +111,13 @@ service_import() {
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local SERVICE_HOST_ROOT="$PLUGIN_DATA_HOST_ROOT/$SERVICE"
   local SERVICE_NAME="$(get_service_name "$SERVICE")"
+  local DATABASE_NAME="$(get_database_name "$SERVICE")"
   local PASSWORD="$(cat "$SERVICE_ROOT/PASSWORD")"
 
   if [[ -t 0 ]]; then
     dokku_log_fail "No data provided on stdin."
   fi
-  docker exec -i "$SERVICE_NAME" mysql --user=mariadb --password="$PASSWORD" "$SERVICE"
+  docker exec -i "$SERVICE_NAME" mysql --user=mariadb --password="$PASSWORD" "$DATABASE_NAME"
 }
 
 service_start() {
@@ -144,7 +150,8 @@ service_start() {
 service_url() {
   local SERVICE="$1"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
-  local PASSWORD="$(cat "$SERVICE_ROOT/PASSWORD")"
   local SERVICE_DNS_HOSTNAME="$(service_dns_hostname "$SERVICE")"
-  echo "$PLUGIN_SCHEME://mariadb:$PASSWORD@$SERVICE_DNS_HOSTNAME:${PLUGIN_DATASTORE_PORTS[0]}/$SERVICE"
+  local DATABASE_NAME="$(get_database_name "$SERVICE")"
+  local PASSWORD="$(cat "$SERVICE_ROOT/PASSWORD")"
+  echo "$PLUGIN_SCHEME://mariadb:$PASSWORD@$SERVICE_DNS_HOSTNAME:${PLUGIN_DATASTORE_PORTS[0]}/$DATABASE_NAME"
 }

--- a/tests/service_create.bats
+++ b/tests/service_create.bats
@@ -7,6 +7,15 @@ load test_helper
   dokku --force "$PLUGIN_COMMAND_PREFIX:destroy" l
 }
 
+@test "($PLUGIN_COMMAND_PREFIX:create) service with dashes" {
+  run dokku "$PLUGIN_COMMAND_PREFIX:create" service-with-dashes
+  assert_contains "${lines[*]}" "container created: service-with-dashes"
+  assert_contains "${lines[*]}" "dokku-$PLUGIN_COMMAND_PREFIX-service-with-dashes"
+  assert_contains "${lines[*]}" "service_with_dashes"
+
+  dokku --force "$PLUGIN_COMMAND_PREFIX:destroy" service-with-dashes
+}
+
 @test "($PLUGIN_COMMAND_PREFIX:create) error when there are no arguments" {
   run dokku "$PLUGIN_COMMAND_PREFIX:create"
   assert_contains "${lines[*]}" "Please specify a valid name for the service"
@@ -14,8 +23,5 @@ load test_helper
 
 @test "($PLUGIN_COMMAND_PREFIX:create) error when there is an invalid name specified" {
   run dokku "$PLUGIN_COMMAND_PREFIX:create" d.erp
-  assert_failure
-
-  run dokku "$PLUGIN_COMMAND_PREFIX:create" d-erp
   assert_failure
 }


### PR DESCRIPTION
This PR allows dashes in service names, while still sanitizing them before they are used as database names. If the datastore is pre-existing, the datatabase name is assumed to be the same as the service name, and returned appropriately.